### PR TITLE
feat: Implement "mark as answered" for questions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,78 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // --- Admin List (Hardcoded) ---
+    function getAdminUIDs() {
+      return [
+        "p9C3Ld9rHuPfe2synovUe3N1K4h1", // woo
+        "LGA38I8WjgOLgzN2nKlW0KtGUUo2", // sci
+        "WHj6mkqbiONyGuPvxqAm1K1UzOo1"  // fls
+      ];
+    }
+
+    function isAdmin() {
+      return request.auth != null && request.auth.uid in getAdminUIDs();
+    }
+
+    // Questions collection
+    match /questions/{questionId} {
+      allow read: if true;
+
+      allow create: if request.auth != null &&
+                      request.resource.data.userId == request.auth.uid &&
+                      request.resource.data.text is string &&
+                      request.resource.data.votes == 0 &&
+                      request.resource.data.votedBy is list &&
+                      request.resource.data.votedBy.size() == 0 &&
+                      request.resource.data.createdAt == request.time &&
+                      request.resource.data.answered == false && // Initialize answered to false
+                      request.resource.data.answered is bool &&   // Ensure answered is a boolean
+                      !('userName' in request.resource.data);
+
+      allow update: if request.auth != null &&
+                      (
+                        // Scenario 1: Admin marks question as answered/unanswered
+                        (
+                          isAdmin() &&
+                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answered']) &&
+                          request.resource.data.answered is bool &&
+                          // Ensure other fields remain unchanged
+                          request.resource.data.text == resource.data.text &&
+                          request.resource.data.userId == resource.data.userId &&
+                          request.resource.data.createdAt == resource.data.createdAt &&
+                          request.resource.data.votes == resource.data.votes &&
+                          request.resource.data.votedBy == resource.data.votedBy
+                        ) ||
+                        // Scenario 2: User votes on a question (existing logic)
+                        (
+                          // Ensure only 'votes' and 'votedBy' can be changed by non-admins for voting
+                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['votes', 'votedBy']) &&
+                          // Ensure 'answered' field is not changed during voting
+                          request.resource.data.answered == resource.data.answered &&
+                          // Ensure other critical fields remain unchanged
+                          request.resource.data.text == resource.data.text &&
+                          request.resource.data.userId == resource.data.userId &&
+                          request.resource.data.createdAt == resource.data.createdAt &&
+                          (
+                            // Sub-Scenario 2.1: Voting (adding a vote)
+                            (
+                              !(request.auth.uid in resource.data.votedBy) && // User was NOT in old list
+                              request.resource.data.votedBy == resource.data.votedBy.concat([request.auth.uid]) &&
+                              request.resource.data.votes == resource.data.votes + 1
+                            ) ||
+                            // Sub-Scenario 2.2: Unvoting (removing a vote)
+                            (
+                              request.auth.uid in resource.data.votedBy && // User WAS in old list
+                              request.resource.data.votedBy.size() == resource.data.votedBy.size() - 1 &&
+                              request.resource.data.votedBy.hasAll( resource.data.votedBy.removeAll([request.auth.uid]) ) &&
+                              request.resource.data.votes == resource.data.votes - 1
+                            )
+                          )
+                        )
+                      );
+
+      allow delete: if request.auth != null &&
+                      (resource.data.userId == request.auth.uid || isAdmin());
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -214,3 +214,43 @@ h1 {
     color: #aaaaaa; /* Lighter gray for this message */
     margin-right: 10px; /* Space before remove button if it's there */
 }
+
+/* Styling for Answered Questions */
+.answered-question {
+    opacity: 0.65; /* Reduce opacity to make it look "turned off" */
+    background-color: #3a3a3a; /* Darker, more desaturated background */
+    border-left-color: #666666; /* Gray border to make it less prominent */
+    /* box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15); /* Optionally reduce shadow */
+}
+
+/* Ensure admin controls within an answered question remain fully visible and interactive */
+.answered-question .question-actions .answered-label,
+.answered-question .question-actions .answered-checkbox {
+    opacity: 1; /* Counteract parent's opacity */
+}
+
+/* Optional: Adjust hover effect for answered questions if needed */
+/* For example, if there was a general .question-item:hover effect, you might do:
+.answered-question:hover {
+    background-color: #3f3f3f; // Slightly less pronounced hover
+}
+*/
+
+/* Styling for the admin's "Mark Answered" checkbox and label */
+.answered-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #E0E0E0; /* Light text color */
+    margin-left: 10px; /* Space from other buttons */
+}
+
+.answered-checkbox {
+    margin-right: 5px;
+    /* Default browser checkbox styles will apply.
+       Custom styling checkboxes can be complex and might be out of scope
+       unless specifically requested. */
+    /* Make checkbox slightly larger if desired, but can be tricky cross-browser */
+    /* transform: scale(1.2); */
+}


### PR DESCRIPTION
This feature allows admin users to mark questions as answered.

Key changes:
- Updated Firestore security rules:
  - Added an `answered` field (boolean) to questions.
  - New questions default to `answered: false`.
  - Only admin users can modify the `answered` field.
- Modified `script.js`:
  - Admin users now see a checkbox to toggle the answered status of questions.
  - Question creation initializes `answered` to `false`.
  - `renderQuestions` function updated to:
    - Display the admin checkbox.
    - Add an `answered-question` class to answered questions for styling.
  - Added `handleMarkAsAnswered` function to update Firestore.
  - Synchronized `adminUIDs` with Firestore rules.
- Updated `style.css`:
  - Added styles for the `.answered-question` class to make them visually distinct (dimmed, different background/border).
  - Ensured admin controls (checkbox/label) remain fully interactive on answered questions by overriding opacity.
  - Added minor styling for the admin checkbox and its label.

The functionality allows questions to be marked as resolved while remaining in their original order, visible but "turned off".