### PR TITLE
feat: Add visual indicator for answered questions

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,6 +210,13 @@ document.addEventListener('DOMContentLoaded', () => {
             questionText.classList.add('question-text');
             // Make sure question.text exists, especially if there are DB schema inconsistencies
             questionText.textContent = question.text || "[No question text]"; 
+
+            if (question.answered === true) {
+                const answeredIndicator = document.createElement('span');
+                answeredIndicator.textContent = " (Answered)";
+                answeredIndicator.classList.add('answered-text-indicator');
+                questionText.appendChild(answeredIndicator);
+            }
             // Author name display removed as per requirement
 
 

--- a/style.css
+++ b/style.css
@@ -166,6 +166,14 @@ h1 {
     color: #FFFFFF; /* Brighter white for question text */
 }
 
+.answered-text-indicator {
+    font-size: 0.85em; /* Slightly larger than 0.8 for better readability */
+    color: #B0B0B0;   /* A lighter gray than #A0A0A0 for better visibility on #424242 bg */
+    font-style: italic;
+    font-weight: normal; /* Ensure it's not bold if .question-text is */
+    /* margin-left is not strictly needed due to space in textContent " (Answered)" */
+}
+
 .question-actions {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This commit adds a small "(Answered)" text next to the question when it has been marked as answered.

- `script.js`: Modified `renderQuestions` to dynamically create and append a styled span with the text " (Answered)" to the question text if the question's `answered` property is true.
- `style.css`: Added styling for the `.answered-text-indicator` class to make the text smaller, italic, and visually distinct from the main question content.